### PR TITLE
Add devcontainers-extra versions from the collections index for installsAfter

### DIFF
--- a/src/localstack-cli/devcontainer-feature.json
+++ b/src/localstack-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "localstack-cli",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "name": "LocalStack CLI",
     "documentationURL": "https://github.com/localstack/devcontainer-feature/tree/main/src/localstack-cli",
     "description": "Installs the Localstack CLI along with needed dependencies and popular \"local\" tools.",
@@ -60,10 +60,8 @@
             "ghcr.io/devcontainers/features/python",
             "ghcr.io/devcontainers/features/node",
             "ghcr.io/devcontainers/features/aws-cli",
-            "ghcr.io/devcontainers-contrib/features/aws-cdk",
             "ghcr.io/devcontainers-extra/features/aws-cdk",
             "ghcr.io/customink/codespaces-features/sam-cli",
-            "ghcr.io/devcontainers-contrib/features/pulumi",
             "ghcr.io/devcontainers-extra/features/pulumi",
             "ghcr.io/devcontainers/features/terraform"
     ]

--- a/src/localstack-cli/devcontainer-feature.json
+++ b/src/localstack-cli/devcontainer-feature.json
@@ -61,8 +61,10 @@
             "ghcr.io/devcontainers/features/node",
             "ghcr.io/devcontainers/features/aws-cli",
             "ghcr.io/devcontainers-contrib/features/aws-cdk",
+            "ghcr.io/devcontainers-extra/features/aws-cdk",
             "ghcr.io/customink/codespaces-features/sam-cli",
             "ghcr.io/devcontainers-contrib/features/pulumi",
+            "ghcr.io/devcontainers-extra/features/pulumi",
             "ghcr.io/devcontainers/features/terraform"
     ]
 }


### PR DESCRIPTION
Adding `devcontainers-extra` versions for `installsAfter`.

- `"ghcr.io/devcontainers-extra/features/aws-cdk",`
- `"ghcr.io/devcontainers-extra/features/pulumi",`

Ref: 
- https://github.com/devcontainers/devcontainers.github.io/issues/451
- https://github.com/devcontainers/devcontainers.github.io/blob/gh-pages/_data/collection-index.yml